### PR TITLE
Handle duplicate table creation

### DIFF
--- a/handler/createtable.go
+++ b/handler/createtable.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -13,10 +14,15 @@ import (
 )
 
 func CreateTable(ctx context.Context, s *state, input *dynamodb.CreateTableInput) (*dynamodb.CreateTableOutput, error) {
-	// TODO: Check if table already exists
+	key := fmt.Sprintf("$table:%s", *input.TableName)
+
+	if _, err := s.kv.Get(ctx, []byte(key)); err == nil {
+		return nil, ErrResourceInUse
+	} else if !errors.Is(err, ErrNotFound) {
+		return nil, err
+	}
 
 	now := time.Now()
-	key := fmt.Sprintf("$table:%s", *input.TableName)
 
 	td := &types.TableDescription{
 		TableId:              aws.String(shortuuid.New()),

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -245,9 +245,12 @@ func handle[I any, O any](
 
 	resp, err := fn(request.Context(), s, i)
 	if err != nil {
-		if errors.Is(err, ErrNotFound) {
+		switch {
+		case errors.Is(err, ErrResourceInUse):
+			sendDDBError(writer, 400, "com.amazonaws.dynamodb.v20120810#ResourceInUseException", err.Error())
+		case errors.Is(err, ErrNotFound):
 			sendDDBError(writer, 400, "com.amazonaws.dynamodb.v20120810#ResourceNotFoundException", "Requested resource not found")
-		} else {
+		default:
 			sendDDBError(writer, 500, "com.amazonaws.dynamodb.v20120810#InternalServerError", err.Error())
 		}
 		return

--- a/handler/kv.go
+++ b/handler/kv.go
@@ -6,7 +6,8 @@ import (
 )
 
 var (
-	ErrNotFound = errors.New("not found")
+	ErrNotFound      = errors.New("not found")
+	ErrResourceInUse = errors.New("resource in use")
 )
 
 type KVStore interface {


### PR DESCRIPTION
## Summary
- check for existing table entries before creating a new table
- return DynamoDB ResourceInUseException when attempting to create an existing table
- surface ResourceInUse errors through the generic handler response logic

## Testing
- go test ./... *(fails: command hung, interrupted)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69515dbb9b70832abb5723dfa3a01476)