### PR TITLE
Handle duplicate CreateTable requests

### DIFF
--- a/handler/createtable.go
+++ b/handler/createtable.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -13,10 +14,14 @@ import (
 )
 
 func CreateTable(ctx context.Context, s *state, input *dynamodb.CreateTableInput) (*dynamodb.CreateTableOutput, error) {
-	// TODO: Check if table already exists
-
 	now := time.Now()
 	key := fmt.Sprintf("$table:%s", *input.TableName)
+
+	if _, err := s.kv.Get(ctx, []byte(key)); err == nil {
+		return nil, ErrAlreadyExists
+	} else if !errors.Is(err, ErrNotFound) {
+		return nil, err
+	}
 
 	td := &types.TableDescription{
 		TableId:              aws.String(shortuuid.New()),

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -247,6 +247,8 @@ func handle[I any, O any](
 	if err != nil {
 		if errors.Is(err, ErrNotFound) {
 			sendDDBError(writer, 400, "com.amazonaws.dynamodb.v20120810#ResourceNotFoundException", "Requested resource not found")
+		} else if errors.Is(err, ErrAlreadyExists) {
+			sendDDBError(writer, 400, "com.amazonaws.dynamodb.v20120810#ResourceInUseException", "Table already exists")
 		} else {
 			sendDDBError(writer, 500, "com.amazonaws.dynamodb.v20120810#InternalServerError", err.Error())
 		}

--- a/handler/kv.go
+++ b/handler/kv.go
@@ -7,6 +7,8 @@ import (
 
 var (
 	ErrNotFound = errors.New("not found")
+
+	ErrAlreadyExists = errors.New("already exists")
 )
 
 type KVStore interface {

--- a/itest/suite.go
+++ b/itest/suite.go
@@ -34,6 +34,13 @@ func New(t *testing.T, url string) *Suite {
 	return &Suite{db: db}
 }
 
+func (s *Suite) SetupTest() {
+	testTableName := "TestTable"
+	_, _ = s.db.DeleteTable(context.Background(), &dynamodb.DeleteTableInput{
+		TableName: aws.String(testTableName),
+	})
+}
+
 func (s *Suite) TestCreateTable() {
 	testTableName := "TestTable"
 	_, err := s.db.CreateTable(context.Background(), &dynamodb.CreateTableInput{


### PR DESCRIPTION
## Summary
- add a dedicated error for existing tables and surface it as a DynamoDB ResourceInUseException
- check for existing table keys before creating new tables
- reset the test table between integration test cases to allow repeated table creation

## Testing
- go test ./...


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69515fbb2cc8832a9a3338e67b291097)