### PR TITLE
ci: bump GitHub Actions versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
           go-version-file: 'go.mod'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v8.1.0
 
       - name: Install just
         uses: extractions/setup-just@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,20 +18,20 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Install Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: 'go.mod'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v8
 
       - name: Install just
-        uses: extractions/setup-just@v3
+        uses: extractions/setup-just@v4
 
       - name: Run tests
         run: just test


### PR DESCRIPTION
## Summary
- Bump workflow action versions where newer tags are available.
- Move core GitHub Actions to Node 24-capable major versions where applicable.

## Verification
- Existing GitHub Actions workflows will validate this PR.